### PR TITLE
Add script to generate contracts from gsheet

### DIFF
--- a/Contratos/README.md
+++ b/Contratos/README.md
@@ -1,2 +1,25 @@
 # Contratos
+
 Este repositorio contiene plantillas de contratos HTML generados automáticamente.
+
+## Generación de contratos
+
+Se incluye un script `generate_contracts.py` que toma los datos de una hoja de cálculo de Google y rellena la plantilla `templates/contract_template.html` para crear un archivo HTML por cada trabajador.
+
+### Requisitos
+
+Instalar las dependencias de Python:
+
+```bash
+pip install -r requirements.txt
+```
+
+Debe existir un archivo `service_account.json` con las credenciales de una cuenta de servicio de Google que tenga acceso a la planilla. Ajuste en el script el nombre de la planilla si es necesario.
+
+### Uso
+
+```bash
+python generate_contracts.py
+```
+
+Los contratos generados se guardarán en la carpeta `Contratos/` con el nombre de cada trabajador.

--- a/generate_contracts.py
+++ b/generate_contracts.py
@@ -1,0 +1,56 @@
+import json
+import os
+from typing import List, Dict
+
+import gspread
+from jinja2 import Environment, FileSystemLoader
+
+TEMPLATE_DIR = 'templates'
+TEMPLATE_NAME = 'contract_template.html'
+OUTPUT_DIR = 'Contratos'
+SERVICE_ACCOUNT_FILE = 'service_account.json'  # ruta del archivo de la cuenta de servicio
+SPREADSHEET_NAME = 'Contratos'  # nombre de la hoja de cálculo a abrir
+
+
+def load_data() -> List[Dict]:
+    gc = gspread.service_account(filename=SERVICE_ACCOUNT_FILE)
+    sh = gc.open(SPREADSHEET_NAME).sheet1
+    records = sh.get_all_records()
+    # convertir columnas en listas si vienen en formato JSON
+    for record in records:
+        for key in ['sueldos_base', 'bonos', 'no_imponibles']:
+            value = record.get(key)
+            if isinstance(value, str) and value:
+                try:
+                    record[key] = json.loads(value)
+                except json.JSONDecodeError:
+                    record[key] = []
+            else:
+                record[key] = []
+    return records
+
+
+def render_contract(empleado: Dict, template):
+    return template.render(empleado=empleado)
+
+
+def save_contract(html: str, filename: str):
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    path = os.path.join(OUTPUT_DIR, filename)
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(html)
+
+
+def main():
+    env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
+    template = env.get_template(TEMPLATE_NAME)
+    records = load_data()
+    for rec in records:
+        nombre = rec.get('nombre_completo', 'contrato').replace(' ', '_')
+        html = render_contract(rec, template)
+        save_contract(html, f'{nombre}.html')
+    print(f'Se generaron {len(records)} contratos en la carpeta {OUTPUT_DIR}')
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+gspread
+jinja2

--- a/templates/contract_template.html
+++ b/templates/contract_template.html
@@ -1,0 +1,45 @@
+<h1 style="text-align:center"><strong>Contrato de Trabajo por Obra</strong></h1>
+
+<p>En Santiago de Chile, <strong>Lunes 23 de junio del 2025</strong>, entre <strong>Kronos Mining Ingeniería y Revestimiento Ltda.</strong>, R.U.T. <strong>76.142.966-3</strong>, en adelante también "el empleador", representado por Don <strong>Pablo Gines Escanella Salinas</strong>, R.U.T. <strong>9.581.567-7</strong>, ambos domiciliados en <strong>Cerro Los Cóndores 9871, Quilicura</strong>, por una parte; y por la otra, Don(a) <strong>{{empleado.nombre_completo}}</strong>, R.U.T. <strong>{{empleado.rut}}</strong>, domiciliado en calle <strong>{{empleado.direccion}}</strong>, comuna de <strong>{{empleado.comuna}}</strong>, ciudad de <strong>{{empleado.ciudad}}</strong>, en adelante también "el trabajador", se ha convenido el siguiente Contrato Individual de Trabajo por Obra:</p>
+
+<p><strong>PRIMERO</strong>: El trabajador se compromete a prestar servicios en el área de <strong>Operaciones en terreno</strong> como <strong>{{empleado.nombre_del_cargo}}</strong> u otro trabajo o función similar relacionada directamente con dicho cargo, en la obra ubicada en <strong>Av. Pdte. Kennedy Lateral, 9001 Las Condes, Región Metropolitana</strong>. No obstante, el empleador podrá modificar el lugar o funciones del trabajador por razones fundadas, sin que ello implique menoscabo para el trabajador.</p>
+
+<p><strong>SEGUNDO</strong>: El trabajador percibirá una remuneración de:</p>
+<ul>
+<li><strong>Sueldo base:</strong> ${{empleado.sueldo}}</li>
+{% for sueldo in empleado.sueldos_base %}
+<li><strong>{{sueldo.nombre}}:</strong> ${{sueldo.monto}}</li>
+{% endfor %}
+{% for bono in empleado.bonos %}
+<li><strong>{{bono.nombre}}:</strong> ${{bono.monto}}</li>
+{% endfor %}
+{% for bono in empleado.no_imponibles %}
+<li><strong>{{bono.nombre}}:</strong> ${{bono.monto}}</li>
+{% endfor %}
+</ul>
+<p>Las remuneraciones se pagarán por períodos vencidos el día <strong>30</strong> de cada mes, mediante depósito en cuenta vista informada por el trabajador, en moneda nacional.</p>
+
+<p><strong>TERCERO</strong>: Se pacta una jornada ordinaria semanal de <strong>44 horas</strong>, distribuidas de lunes a jueves desde las <strong>08:00 a 17:30</strong> horas y los viernes desde <strong>08:00 a 16:30</strong> horas, con una pausa para colación de 30 minutos entre las 13:00 y 13:30 horas.</p>
+
+<p><strong>CUARTO</strong>: El presente contrato tendrá vigencia desde el <strong>23 de junio de 2025</strong> y se mantendrá vigente hasta la total finalización de la obra antes señalada. Cualquiera de las partes podrá poner término anticipado conforme a las causales establecidas en el Código del Trabajo.</p>
+
+<p><strong>QUINTO</strong>: Las demás condiciones laborales se regirán conforme al Código del Trabajo, al Reglamento Interno de Orden, Higiene y Seguridad, y a la normativa vigente aplicable a los contratos por obra o faena.</p>
+
+<p><strong>SEXTO</strong>: Ambas partes declaran haber leído y comprendido íntegramente el presente contrato, firmándolo en dos ejemplares de igual tenor, quedando uno en poder de cada parte.</p>
+
+<table align="center" border="0" cellpadding="1" cellspacing="1" style="width:100%">
+  <tr>
+    <td style="text-align:center">
+      <p>FIRMA EMPLEADOR</p>
+      <br><br>
+      <p>Pablo Gines Escanella Salinas</p>
+      <p>RUT: 9.581.567-7</p>
+    </td>
+    <td style="text-align:center">
+      <p>FIRMA TRABAJADOR</p>
+      <br><br>
+      <p>{{empleado.nombre_completo}}</p>
+      <p>RUT: {{empleado.rut}}</p>
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
## Summary
- add contract HTML template
- add `generate_contracts.py` for filling contracts from Google Sheets
- document usage in README
- specify Python requirements

## Testing
- `python -m py_compile generate_contracts.py`

------
https://chatgpt.com/codex/tasks/task_e_6855ae3f39f4832aa3ff577069acc1e6